### PR TITLE
Update buildpack to use MongoDB 3.6.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,10 @@
-# Heroku Buildpack: MongoDB 4.1.5
+# Yesware Forked Heroku Buildpack: MongoDB 3.6.17
 
 This is a [Heroku buildpack](http://devcenter.heroku.com/articles/buildpacks) to run mongo commands (http://www.mongodb.org/). <br/>
-It installs MongoDB 4.1.5 for Ubuntu 18.04 (stack: heroku-18).
+It installs MongoDB 3.6.17 for Ubuntu 16.04 (stack: heroku-16).
 
 Usage
 -----
 
-Example usage:
-
-    $ heroku create myapp --buildpack http://github.com/siesgstarena/heroku-buildpack-mongo.git
-    $ git push heroku master
-
-or:
-	
-	$ heroku buildpacks:add http://github.com/siesgstarena/heroku-buildpack-mongo.git
+Example usage:	
+	$ heroku buildpacks:add http://github.com/Yesware/heroku-buildpack-mongo.git

--- a/bin/compile
+++ b/bin/compile
@@ -14,10 +14,10 @@ heroku_dir=$build_dir/.heroku
 mkdir -p $heroku_dir/mongo
 warnings=$(mktemp)
 
-# Install MongoDB 4.0 to use mongo commands
-mongo_version="4.1.5"
+# Install MongoDB 3.6 to use mongo commands
+mongo_version="3.6.17"
 echo "-----> Downloading and installing MongoDB version ${mongo_version}..."
-[[ $STACK = "heroku-18" ]] && os_id="ubuntu1804"
+[[ $STACK = "heroku-16" ]] && os_id="ubuntu1604"
 
 file_name="mongodb-linux-x86_64-${os_id}-${mongo_version}.tgz"
 folder_name=`echo "$file_name" | sed 's/\.tgz$//'`


### PR DESCRIPTION
Updates the forked buildpack to be compatible with MongoDB 3.6.17 and our Heroku 16 stack,